### PR TITLE
FIT-8548 Map decimal percent fields as string to match DBAL

### DIFF
--- a/src/Model/AbstractInvoiceModel.php
+++ b/src/Model/AbstractInvoiceModel.php
@@ -103,7 +103,7 @@ abstract class AbstractInvoiceModel extends StripeModel
     protected ?int $tax = null;
 
     #[StripeObjectParam(name: 'tax_percent')]
-    protected ?float $taxPercent = null;
+    protected ?string $taxPercent = null;
 
     #[StripeObjectParam]
     protected ?int $total = null;
@@ -487,12 +487,12 @@ abstract class AbstractInvoiceModel extends StripeModel
 
     public function getTaxPercent(): ?float
     {
-        return $this->taxPercent;
+        return null === $this->taxPercent ? null : (float) $this->taxPercent;
     }
 
     public function setTaxPercent(?float $taxPercent): static
     {
-        $this->taxPercent = $taxPercent;
+        $this->taxPercent = null === $taxPercent ? null : number_format($taxPercent, 2, '.', '');
 
         return $this;
     }

--- a/src/Model/AbstractSubscriptionModel.php
+++ b/src/Model/AbstractSubscriptionModel.php
@@ -7,7 +7,7 @@ use Miracode\StripeBundle\Annotation\StripeObjectParam;
 abstract class AbstractSubscriptionModel extends StripeModel
 {
     #[StripeObjectParam(name: 'application_fee_percent')]
-    protected ?float $applicationFeePercent = null;
+    protected ?string $applicationFeePercent = null;
 
     #[StripeObjectParam]
     protected ?string $billing = null;
@@ -67,7 +67,7 @@ abstract class AbstractSubscriptionModel extends StripeModel
     protected ?string $status = null;
 
     #[StripeObjectParam(name: 'tax_percent')]
-    protected ?float $taxPercent = null;
+    protected ?string $taxPercent = null;
 
     #[StripeObjectParam(name: 'trial_end')]
     protected ?int $trialEnd = null;
@@ -77,12 +77,12 @@ abstract class AbstractSubscriptionModel extends StripeModel
 
     public function getApplicationFeePercent(): ?float
     {
-        return $this->applicationFeePercent;
+        return null === $this->applicationFeePercent ? null : (float) $this->applicationFeePercent;
     }
 
     public function setApplicationFeePercent(?float $applicationFeePercent): static
     {
-        $this->applicationFeePercent = $applicationFeePercent;
+        $this->applicationFeePercent = null === $applicationFeePercent ? null : number_format($applicationFeePercent, 2, '.', '');
 
         return $this;
     }
@@ -305,12 +305,12 @@ abstract class AbstractSubscriptionModel extends StripeModel
 
     public function getTaxPercent(): ?float
     {
-        return $this->taxPercent;
+        return null === $this->taxPercent ? null : (float) $this->taxPercent;
     }
 
     public function setTaxPercent(?float $taxPercent): static
     {
-        $this->taxPercent = $taxPercent;
+        $this->taxPercent = null === $taxPercent ? null : number_format($taxPercent, 2, '.', '');
 
         return $this;
     }


### PR DESCRIPTION
## Summary
Map the `decimal` percent fields as PHP `string` (not `float`) so `doctrine:schema:validate` passes in consuming apps.

A `decimal` DBAL column hydrates to a PHP **string**, so a `?float` property is technically inconsistent — Mission Control's `doctrine:schema:validate` reports `AbstractInvoiceModel#taxPercent`, `AbstractSubscriptionModel#applicationFeePercent`/`taxPercent` (and the inherited `SSubscription` fields) as mapping errors. This blocks re-enabling the `schema:validate` CI gate (FIT-8548 in Mission Control; follow-up to the gates introduced in FIT-8545).

Fix mirrors the approach used in Mission Control (FIT-8548): the backing property becomes `?string` while the **getter/setter signatures stay `?float`**, with the conversion done inside the accessors (`(float)` on read, `number_format($v, 2, '.', '')` on write, matching the `scale=2` column). External behaviour and the Stripe hydration path (which goes through the `?float` setters) are unchanged; the DB column stays `decimal` (no migration).

## Changes
- `src/Model/AbstractSubscriptionModel.php` — `applicationFeePercent`, `taxPercent`: property `?float` → `?string`; cast inside getter/setter (signatures unchanged).
- `src/Model/AbstractInvoiceModel.php` — `taxPercent`: same.

## Verification
- `php -l` clean; `php-cs-fixer` reports 0 files to fix.
- Verified in Mission Control by overlaying the changed models into vendor: `doctrine:schema:validate` no longer reports `AbstractInvoiceModel`, `AbstractSubscriptionModel`, or `SSubscription` percent mismatches.
- Doctrine XML mappings unchanged (`type="decimal" scale="2"`) — no schema/migration change.
- No bundle tests reference these fields.

## Follow-up (consumer side)
After this is released (new 3.1.x), Mission Control bumps the bundle and re-enables the `doctrine:schema:validate` gate.
